### PR TITLE
Added ability to add Named Entities

### DIFF
--- a/ECS/Entity.cs
+++ b/ECS/Entity.cs
@@ -5,8 +5,8 @@ using System.Collections.Generic;
 namespace ECS
 {
 	// is the facade for different components, a bag for data and simple operations
-    public class Entity
-    {
+    public class Entity : IEquatable<Entity>
+	{
         public readonly List<IComponent> components;
 
         public Entity()
@@ -15,11 +15,20 @@ namespace ECS
             components = new List<IComponent>();
         }
 
+		public Entity(string _id)
+		{
+			Id = _id;
+			EntityMatcher.Subscribe(this);
+			components = new List<IComponent>();
+		}
+
         ~Entity()
         {
             EntityMatcher.Unsubscribe(this);
-            RemoveAllComponent();
+			RemoveAllComponents();
         }
+
+		public string Id = string.Empty;
 
 		// Add new component to the entity, can support doubles of components
         public Entity AddComponent(IComponent newComponent, bool notifySystems = true)
@@ -38,8 +47,24 @@ namespace ECS
 			return this;
         }
 
+		public Entity AddComponents(bool notifySystems = true, params IComponent[] components)
+		{
+			foreach (IComponent i in components)
+			{
+				AddComponent(i);
+			}
+
+			if(components.Count() == 0)
+			{
+				Console.WriteLine("Component that you intented to add is null, method will return void");
+				return this;
+			}
+
+			return this;
+		}
+
 		// Will replace component if there is a match, if not it will add it as a new component
-        public void ReplaceComponent(IComponent replaceComponent, bool notifySystems = true)
+        public Entity ReplaceComponent(IComponent replaceComponent, bool notifySystems = true)
         {
             if (replaceComponent == null)
             {
@@ -63,7 +88,7 @@ namespace ECS
             return AddComponent(replaceComponent, notifySystems);
         }
 
-		public void RemoveComponent<T>() where T : class, IComponent
+		public void RemoveComponents<T>() where T : class, IComponent
 		{
 			for(int i = 0; i < components.Count; i ++)
 				if (components[i] is T)
@@ -74,7 +99,7 @@ namespace ECS
 			}
 		}
 		
-		public void RemoveAllComponent()
+		public void RemoveAllComponents()
 		{
 			for (int i = 0; i < components.Count; i++)
 			{
@@ -156,5 +181,10 @@ namespace ECS
 				   && HasAnyComponent(request.AnyType.ToArray()) 
 				   && HasNoneComponent(request.NoneType.ToArray());
 		}
-    }
+
+		public bool Equals(Entity other)
+		{
+			return this.Id == other.Id;
+		}
+	}
 }

--- a/ECS/Entity.cs
+++ b/ECS/Entity.cs
@@ -88,7 +88,7 @@ namespace ECS
             return AddComponent(replaceComponent, notifySystems);
         }
 
-		public void RemoveComponents<T>() where T : class, IComponent
+		public void RemoveComponent<T>() where T : class, IComponent
 		{
 			for(int i = 0; i < components.Count; i ++)
 				if (components[i] is T)

--- a/ECS/EntityMatcher.cs
+++ b/ECS/EntityMatcher.cs
@@ -19,6 +19,12 @@ namespace ECS
         {
 			if (entity == null) throw new ArgumentNullException();
 
+			if (string.IsNullOrEmpty(entity.Id))
+				throw new Exception("The Entity Id you entered was blank or null.");
+
+			if (subscribedEntities.Any(ent => ent.Id == entity.Id))
+				throw new Exception("This entity already exists.");
+
             if (!subscribedEntities.Contains(entity))
             {
                 subscribedEntities.Add(entity);
@@ -27,6 +33,31 @@ namespace ECS
             }
             else Console.WriteLine("Entity is already subscribed");
         }
+
+		public static Entity GetEntity(string whichEntity)
+		{
+			return subscribedEntities.First(_ => _.Id == whichEntity);
+		}
+
+		public static bool DoesEntityExist(string whichEntity)
+		{
+			return subscribedEntities.Any(_ => _.Id == whichEntity);
+		}
+
+		public static void Remove(string whichEntity)
+		{
+			subscribedEntities.Remove(GetEntity(whichEntity));
+		}
+
+		public static bool Remove(Entity whichEntity)
+		{
+			return subscribedEntities.Remove(whichEntity);
+		}
+
+		public static void RemoveAll()
+		{
+			subscribedEntities.Clear();
+		}
 
 		// Entity deconstructor will unsubriscribe with this method
         public static void Unsubscribe(Entity entity)

--- a/ECSTests/EntityMatcherTests.cs
+++ b/ECSTests/EntityMatcherTests.cs
@@ -55,7 +55,23 @@ namespace ECSTests
 			Assert.AreEqual(0, EntityMatcher.subscribedEntities.Count);
 		}
 
-		[ExpectedException]
+
+        [Test()]
+        public void ShouldNotSubscibeBlankId()
+        {
+            EntityMatcher.Subscribe(testEntity);
+            Assert.AreEqual(0, EntityMatcher.subscribedEntities.Count);
+        }
+
+        [Test()]
+        public void ShouldNotDuplicateIds()
+        {
+            EntityMatcher.Subscribe(testEntity);
+            EntityMatcher.Subscribe(testEntity);
+            Assert.AreEqual(1, EntityMatcher.subscribedEntities.Count);
+        }
+
+        [ExpectedException]
 		public void ThrowExceptionWhenPassNullFilter()
 		{
 			EntityMatcher.GetMatchedEntities(null);

--- a/ECSTests/EntityTests.cs
+++ b/ECSTests/EntityTests.cs
@@ -1,6 +1,7 @@
 using System;
 using NUnit.Framework;
 using ECS;
+using System.Collections.Generic;
 
 namespace ECSTests
 {
@@ -11,8 +12,9 @@ namespace ECSTests
 		private Filter testFilter;
 		private FirstTestComponent firstComponent;
 		private SecondTestComponent secondComponent;
+        private IComponent[] componentList;
 
-		[SetUp]
+        [SetUp]
 		public void SetUp()
 		{
 			testEntity = new Entity();
@@ -25,7 +27,7 @@ namespace ECSTests
 		public void TearDown()
 		{
 			testFilter.Reset();
-			testEntity.RemoveAllComponent();
+			testEntity.RemoveAllComponents();
 		}
 
 		[Test()]
@@ -93,7 +95,7 @@ namespace ECSTests
 			testEntity.AddComponent(firstComponent);
 			testEntity.AddComponent(firstComponent);
 			testEntity.AddComponent(secondComponent);
-			testEntity.RemoveAllComponent();
+			testEntity.RemoveAllComponents();
 			Assert.IsFalse(testEntity.HasComponent<FirstTestComponent>());
 			Assert.IsFalse(testEntity.HasComponent<SecondTestComponent>());
 		}
@@ -212,10 +214,19 @@ namespace ECSTests
 			Assert.IsFalse(testEntity.DoesMatchFilter(testFilter));
 			
 			testFilter.Reset();
-			testEntity.RemoveAllComponent();
+			testEntity.RemoveAllComponents();
 			testFilter.NoneOf(typeof(FirstTestComponent), typeof(SecondTestComponent));
 			Assert.IsTrue(testEntity.DoesMatchFilter(testFilter));
 		}
+
+        [Test()]
+        public void AddMultipleComponentsToEntity()
+        {
+            componentList = new IComponent[2] { firstComponent, secondComponent };
+
+            testEntity.AddComponents(true, componentList);
+            Assert.AreEqual(2, testEntity.components.Count);
+        }
 	}
 
 	public class FirstTestComponent : IComponent


### PR DESCRIPTION
Added a feature to the ECS library so that when Entities are added, they can be given a unique String Id so that you can get specific Entities in the future, rather than just retrieving them by Component type.

I was using a different ECS library in my game that was much too slow, and replaced it with this excellent ECS system that is fast, but wanted to add a couple features that made it more of a drop-in replacement.